### PR TITLE
Update bindgen to v0.58

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ links = "purple"
 [build-dependencies]
 pkg-config = "~0.3"
 libc = "~0.2"
-bindgen = "~0.54"
+bindgen = "~0.58"
 

--- a/build.rs
+++ b/build.rs
@@ -8,9 +8,9 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let out_file = Path::new(&out_dir).join("purple.rs");
     let mut bindings = bindgen::builder()
-        .whitelist_type("Purple.*")
-        .whitelist_function("purple_.*")
-        .whitelist_var("PURPLE_.*")
+        .allowlist_type("Purple.*")
+        .allowlist_function("purple_.*")
+        .allowlist_var("PURPLE_.*")
         .bitfield_enum("PurpleIconScaleRules|PurpleProtocolOptions|")
         .newtype_enum("PurplePluginType");
 


### PR DESCRIPTION
bindgen v0.54 transitively pulls in syntex_syntax v0.58.1, which no longer compiles on Rust v1.41+:

https://github.com/rust-lang/rust/issues/68729

I'm hoping to use libpurple-rust in a rust-native reimplementation of https://code.ur.gs/lupine/purple-plugin-delta , which will need to build against Rust v1.50, so fixing this would be nice.

I fixed a few deprecation warnings in build.rs, but otherwise this seems to be a simple update.